### PR TITLE
[Attempt] Fix async event loops

### DIFF
--- a/src/processes.py
+++ b/src/processes.py
@@ -1,9 +1,11 @@
 import logging
 import messages
+import asyncio
+import operations
+
 from collections import defaultdict
 from queue import Queue
 
-import operations
 from nodes import BaseNode
 from cluster import Cluster
 from raft import RaftHelper
@@ -40,6 +42,11 @@ class NodeProcess(object):
 
 class SocketBasedNodeProcess(NodeProcess):
 
+    @staticmethod
+    def init_event_loop():
+        event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(event_loop)
+
     def __init__(self, node: BaseNode, cluster: Cluster, flags=defaultdict(lambda: False)):
         """
             Takes node info as input
@@ -63,6 +70,14 @@ class SocketBasedNodeProcess(NodeProcess):
                 self.cluster.blueprint.node_specific_ops[self.node.node_id],
                 self.sendMessage,
             )
+
+        self.init_event_loop()
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.start())
+        print('here')
+        loop.run_until_complete(self.bootstrap())
+        print('here2')
 
     def startThread(self, thread):
         thread.daemon = True

--- a/src/pub_sub.py
+++ b/src/pub_sub.py
@@ -1,6 +1,7 @@
 import zmq
 import logging
 import pickle
+
 from time import sleep
 from threading import Thread
 from queue import Queue
@@ -10,8 +11,8 @@ log = logging.getLogger()
 
 
 class SubscribeThread(Thread):
-    def __init__(self, node_process: 'SocketBasedNodeProcess', cluster: 'Cluster', callback: 'onMessage'):
-        super(SubscribeThread, self).__init__()
+    def __init__(self, node_process: 'SocketBasedNodeProcess', cluster: 'Cluster', callback: 'onMessage', target=None):
+        super(SubscribeThread, self).__init__(target=target)
 
         self.node_process = node_process
         self.cluster = cluster
@@ -51,8 +52,8 @@ class SubscribeThread(Thread):
 
 class PublishThread(Thread):
 
-    def __init__(self, node_process: 'SocketBasedNodeProcess', message_queue: Queue, delay=0.1):
-        super(PublishThread, self).__init__()
+    def __init__(self, node_process: 'SocketBasedNodeProcess', message_queue: Queue, delay=0.1, target=None):
+        super(PublishThread, self).__init__(target=target)
 
         self.node_process = node_process
         self.message_queue = message_queue

--- a/src/raft.py
+++ b/src/raft.py
@@ -77,8 +77,7 @@ class RaftHelper(object):
         log.debug("Node %s waiting for leader election to complete", self.node_address)
         await raftos.State.wait_for_election_success()
         leader = raftos.get_leader()
-        log.debug("Node %s detected %s as leader node", 
-            self.node_address, leader)
+        log.debug("Node %s detected %s as leader node", self.node_address, leader)
         return leader
 
     async def am_i_leader(self):
@@ -86,17 +85,18 @@ class RaftHelper(object):
         return leader == self.node_address
 
     async def init_flow(self):
-        '''
+        """
             Registers a replicated raftos collection and sets initial values 
             for the initial flow state of the supplychain.
-        '''
+        """
         is_leader = await self.am_i_leader()
         if is_leader:
-            cluster_flow_obj = ctr.bootstrap_shortest_path(self.nodes)            
+            log.debug("Starting to compute init cluster flow on leader: {}".format(self.node_address))
+            cluster_flow_obj = ctr.bootstrap_shortest_path(self.nodes)
             log.debug("Starting to init cluster flow: {} on leader: {}".format(self.node_address, cluster_flow_obj))
             self.cluster_flow = raftos.Replicated(name='cluster_flow')
             await self.cluster_flow.set(cluster_flow_obj)
-            log.info("Finished init cluster flow on leader: {}".format(self.node_address))
+            log.debug("Finished init cluster flow on leader: {}".format(self.node_address))
 
     async def update_flow(self, new_cluster_flow: ctr.ClusterWideFlow):
         """
@@ -104,7 +104,9 @@ class RaftHelper(object):
         """
         is_leader = await self.am_i_leader()
         if is_leader:
+            log.debug("Updating cluster flow: {} on leader: {}".format(self.node_address, new_cluster_flow))
             await self.cluster_flow.set(new_cluster_flow)
+            log.debug("Finished updating cluster flow on leader: {}".format(self.node_address))
             return True
         return False
 


### PR DESCRIPTION
Discuss how to handle async raft_helper function calls in NodeProcess. We require it to modify state, get leader information, etc. But we cannot make Thread run() async directly. Also ideally speaking we should not be executing all NodeProcesses in the same event loop as it involves a barrier-like construct await and makes our system not truly multi-process based.

@raokrutarth Since you're the most familiar with asyncio and implemented the original design, do you have any suggestions on how to proceed? Or hopefully, if there's a super simple solution for this which I overlooked?