### PR TITLE
Narrow log strings

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -15,8 +15,8 @@ logging.basicConfig(
     level=os.environ.get("LOGLEVEL", "DEBUG"),
     datefmt='%H:%M:%S',
     # add %(process)s to the formatter to see PIDs
-    format='%(levelname)-6s | %(threadName)-12s | %(asctime)s - %(filename)-15s:%(lineno)-4d - %(funcName)-25s | %('
-           'message)s',
+    format='%(levelname)-6s  %(asctime)s %(threadName)-12s %(filename)s:%(lineno)s::'
+           '%(funcName)-20s | %(message)s',
 )
 log = logging.getLogger()
 


### PR DESCRIPTION
Each line wraps around on a laptop screen making it difficult to read logs. Narrowing down line while keeping readability same. 